### PR TITLE
Make get-href support PersistentVector data structure that comes from…

### DIFF
--- a/src/halboy/resource.clj
+++ b/src/halboy/resource.clj
@@ -27,9 +27,10 @@
   "Gets a href within a resource"
   [resource key]
   (let [link (get-link resource key)]
-    (if (seq? link)
-      (map :href link)
-      (:href link))))
+    (when (some? link)
+      (if (map? link)
+        (:href link)
+        (map :href link)))))
 
 (defn resources
   "Gets all the embedded resources as a map"
@@ -63,7 +64,7 @@
   (if-let [m (ensure-link m)]
     (let [existing-links (:links resource)
           updated-link (-> (get existing-links rel)
-                           (create-or-append m))]
+                         (create-or-append m))]
       (->Resource
         (assoc existing-links rel updated-link)
         (:embedded resource)
@@ -86,7 +87,7 @@
   (if (some? r)
     (let [existing-resources (:embedded resource)
           updated-resource (-> (get existing-resources key)
-                               (create-or-append r))]
+                             (create-or-append r))]
       (->Resource
         (:links resource)
         (assoc existing-resources key updated-resource)
@@ -123,4 +124,4 @@
    (->Resource {} {} {}))
   ([self]
    (-> (->Resource {} {} {})
-       (add-link :self self))))
+     (add-link :self self))))

--- a/test/halboy/json_test.clj
+++ b/test/halboy/json_test.clj
@@ -66,7 +66,14 @@
 
     (testing "json->resource should parse some json into a resource"
       (is (= resource
-             (haljson/json->resource json-representation)))))
+             (haljson/json->resource json-representation))))
+
+    (testing "get-href should work correctly after applying json->resource"
+      (is (= (-> json-representation
+               (haljson/json->resource)
+               (hal/get-href :ea:admin))
+            ["/admins/2"
+             "/admins/5"]))))
 
   (testing "map->resource should parse links"
     (is (= (hal/new-resource "/orders")


### PR DESCRIPTION
… parsing JSON vectors.

When parsing json->resource, the JSON library parses the JSON vectors into PersistentVectors. PersistentVectors do not implement the ISeq interface and thus do fail the `iseq?` check that was formerly in the `get-href` function. This fix takes care of that.