### PR TITLE
feat(clj-http): new client, replicate http and navigator tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 *.iml
 *.ipr
 *.iws
+lsp/

--- a/project.clj
+++ b/project.clj
@@ -9,9 +9,12 @@
                  [medley "1.0.0"]
                  [uritemplate-clj "1.2.1"]
                  [org.clojure/core.cache "0.7.1"]
-                 [org.bovinegenius/exploding-fish "0.3.6"]]
+                 [org.bovinegenius/exploding-fish "0.3.6"]
+                 [clj-http "3.10.2"]
+                 [clj-http-fake "1.0.3"]]
   :plugins [[lein-eftest "0.5.2"]]
   :profiles {:shared {:dependencies [[nrepl "0.6.0"]]}
              :test   [:shared {:dependencies [[http-kit.fake "0.2.2"]
+                                              [clj-http-fake "1.0.3"]
                                               [eftest "0.5.2"]]}]}
   :eftest {:multithread? false})

--- a/src/halboy/http/clj_http.clj
+++ b/src/halboy/http/clj_http.clj
@@ -1,0 +1,33 @@
+(ns halboy.http.clj-http
+  (:require [halboy.http.protocol :as protocol]
+            [clj-http.client :as client]
+            [halboy.http.utils :as http-utils]
+            [halboy.argutils :refer [deep-merge]]))
+
+(defn- format-for-halboy [response url opts]
+  (merge
+    (select-keys response [:error :body :headers :status])
+    {:url url
+     :raw (assoc response :opts opts)}))
+
+(defn default-clj-http-options [m]
+  (deep-merge
+    {:throw-exceptions false
+     :headers {"Accept"       "application/hal+json"
+               "Content-Type" "application/json"}
+     :as      :text}
+    m))
+
+(deftype CljHttpClient []
+  protocol/HttpClient
+  (exchange [_ {:keys [url] :as opts}]
+    (let [opts (-> opts
+                 (default-clj-http-options)
+                 (http-utils/with-json-body))]
+      (->
+        (client/request opts)
+        (http-utils/parse-json-response)
+        (format-for-halboy url opts)))))
+
+(defn new-http-client []
+  (CljHttpClient.))

--- a/src/halboy/http/default.clj
+++ b/src/halboy/http/default.clj
@@ -1,21 +1,15 @@
 (ns halboy.http.default
   (:require
-    [clojure.walk :refer [stringify-keys keywordize-keys]]
-    [cheshire.core :as json]
+    [clojure.walk :refer [stringify-keys]]
     [org.httpkit.client :as http]
     [halboy.argutils :refer [deep-merge]]
-    [halboy.http.protocol :as protocol])
-  (:import [com.fasterxml.jackson.core JsonParseException]))
+    [halboy.http.protocol :as protocol]
+    [halboy.http.utils :as utils]))
 
 (def default-http-options
   {:as      :text
    :headers {"Content-Type" "application/json"
              "Accept"       "application/hal+json"}})
-
-(defn- update-if-present [m ks fn]
-  (if (get-in m ks)
-    (update-in m ks #(fn %))
-    m))
 
 (defn http-method->fn [method]
   (get-in
@@ -30,22 +24,8 @@
 (defn- with-default-options [m]
   (deep-merge default-http-options m))
 
-(defn- with-json-body [m]
-  (update-if-present m [:body] json/generate-string))
-
-(defn- parse-json-response [response]
-  (try
-    (update-if-present
-      response [:body]
-      #(-> (json/parse-string %)
-         (keywordize-keys)))
-    (catch JsonParseException ex
-           (assoc response
-             :error {:code :not-valid-json
-                     :cause ex}))))
-
 (defn- with-transformed-params [m]
-  (update-if-present m [:query-params] stringify-keys))
+  (utils/update-if-present m [:query-params] stringify-keys))
 
 (defn- format-for-halboy [response]
   (merge
@@ -59,10 +39,10 @@
     (let [request (-> request
                       (with-default-options)
                       (with-transformed-params)
-                      (with-json-body))
+                      (utils/with-json-body))
           http-fn (http-method->fn method)]
       (-> @(http-fn url request)
-          (parse-json-response)
+          (utils/parse-json-response)
           (format-for-halboy)))))
 
 (defn new-http-client []

--- a/src/halboy/http/utils.clj
+++ b/src/halboy/http/utils.clj
@@ -1,0 +1,23 @@
+(ns halboy.http.utils
+  (:require [clojure.walk :refer [keywordize-keys]]
+            [cheshire.core :as json])
+  (:import [com.fasterxml.jackson.core JsonParseException]))
+
+(defn update-if-present [m ks fn]
+  (if (get-in m ks)
+    (update-in m ks #(fn %))
+    m))
+
+(defn with-json-body [m]
+  (update-if-present m [:body] json/generate-string))
+
+(defn parse-json-response [response]
+  (try
+    (update-if-present
+      response [:body]
+      #(-> (json/parse-string %)
+         (keywordize-keys)))
+    (catch JsonParseException ex
+      (assoc response
+        :error {:code :not-valid-json
+                :cause ex}))))

--- a/test/halboy/http/clj_http_test.clj
+++ b/test/halboy/http/clj_http_test.clj
@@ -1,0 +1,171 @@
+(ns halboy.http.clj-http-test
+
+  (:require [clojure.test :refer :all]
+            [halboy.http.protocol :as http]
+            [halboy.http.clj-http :as http-client]
+            [halboy.resource :as hal]
+            [cheshire.core :as json]
+            [clj-http.util :as http-util])
+  (:use clj-http.fake))
+
+(deftest halboy-clj-http-test
+  (let [base-url "https://service.example.com"
+        test-resource (-> (hal/new-resource)
+                        (hal/add-property :test "test"))]
+
+    (testing "GET with content-type: text/html response - should still parse response"
+      (with-fake-routes-in-isolation
+        {base-url {:get (fn [_] {:status  201
+                                 :body    "{}"
+                                 :headers {:content-type "text/html"
+                                           :server       "clj-http.fake"}})}}
+
+        (let [client (http-client/new-http-client)
+              request {:url    base-url
+                       :method :get}
+              response (http/exchange client request)]
+          (is (=
+                (update-in response [:raw] dissoc :request-time)
+                {:body    {}
+                 :headers {:content-type "text/html"
+                           :server       "clj-http.fake"}
+
+                 :raw     {:body                  {}
+                           :headers               {:content-type "text/html"
+                                                   :server       "clj-http.fake"}
+                           :opts                  {:as      :text
+                                                   :headers {"Accept"       "application/hal+json"
+                                                             "Content-Type" "application/json"}
+                                                   :method  :get
+                                                   :url     "https://service.example.com"}
+                           :orig-content-encoding nil
+                           :status                201}
+                 :status  201
+                 :url     "https://service.example.com"})))))
+
+
+    (testing "GET with content-type: application/json response"
+      (let [expected-response-body {:embedded   {}
+                                    :links      {}
+                                    :properties {:test "test"}}
+            expected-response-headers {:content-type "application/json"
+                                       :server       "clj-http.fake"}]
+        (with-fake-routes-in-isolation
+          {base-url {:get (fn [_] {:status  201
+                                   :body    (json/generate-string test-resource)
+                                   :headers {:content-type "application/json"
+                                             :server       "clj-http.fake"}})}}
+
+          (let [client (http-client/new-http-client)
+                request {:url    base-url
+                         :method :get}
+                response (http/exchange client request)]
+            (is (= (update-in response [:raw] dissoc :request-time)
+                  {:body    expected-response-body
+                   :headers expected-response-headers
+
+                   :raw     {:body                  {:embedded   {}
+                                                     :links      {}
+                                                     :properties {:test "test"}}
+                             :headers               {:content-type "application/json"
+                                                     :server       "clj-http.fake"}
+                             :opts                  {:as      :text
+                                                     :headers {"Accept"       "application/hal+json"
+                                                               "Content-Type" "application/json"}
+                                                     :method  :get
+                                                     :url     "https://service.example.com"}
+                             :orig-content-encoding nil
+                             :status                201}
+                   :status  201
+                   :url     "https://service.example.com"}))))))
+
+    (testing "GET with query params and content-type: application/json response"
+      (let [expected-response-body {:embedded   {}
+                                    :links      {}
+                                    :properties {:test "test"}}
+            expected-response-headers {:content-type "application/json"
+                                       :server       "clj-http.fake"}]
+        (with-fake-routes-in-isolation
+          {{:address      base-url
+            :query-params {:user "123"}}
+           (fn [_]
+             {:status  201
+              :body    (json/generate-string test-resource)
+              :headers {:content-type "application/json"
+                        :server       "clj-http.fake"}})}
+
+          (let [client (http-client/new-http-client)
+                request {:url          base-url
+                         :query-params {:user 123}
+                         :method       :get}
+                response (http/exchange client request)]
+            (is (= (update-in response [:raw] dissoc :request-time)
+                  {:body    expected-response-body
+                   :headers expected-response-headers
+
+                   :raw     {:body                  {:embedded   {}
+                                                     :links      {}
+                                                     :properties {:test "test"}}
+                             :headers               {:content-type "application/json"
+                                                     :server       "clj-http.fake"}
+                             :opts                  {:as      :text
+                                                     :query-params {:user 123}
+                                                     :headers {"Accept"       "application/hal+json"
+                                                               "Content-Type" "application/json"}
+                                                     :method  :get
+                                                     :url     "https://service.example.com"}
+                             :orig-content-encoding nil
+                             :status                201}
+                   :status  201
+                   :url     "https://service.example.com"}))))))
+
+    (testing "POST with content-type application/json"
+      (let [expected-request-body (json/generate-string test-resource)
+            expected-request-headers {"Accept"          "application/hal+json"
+                                      "Content-Type"    "application/json"
+                                      "accept-encoding" "gzip, deflate"}]
+        (with-fake-routes-in-isolation
+          {base-url {:post
+                     (fn [req]
+                       (when (and
+                               (= expected-request-body
+                                 (http-util/force-string (:body req) "utf-8"))
+                               (= expected-request-headers
+                                 (:headers req)))
+
+                         {:status  201
+                          :body    (json/generate-string
+                                     (-> (hal/new-resource)
+                                       (hal/add-property :test "test")))
+                          :headers {:content-type "application/json"
+                                    :server       "clj-http.fake"}}))}}
+
+          (let [client (http-client/new-http-client)
+                request {:url    base-url
+                         :body   (-> (hal/new-resource)
+                                   (hal/add-property :test "test"))
+                         :method :post}
+                response (http/exchange client request)]
+
+            (is (= (update-in response [:raw] dissoc :request-time)
+                  {:body    {:embedded   {}
+                             :links      {}
+                             :properties {:test "test"}}
+                   :headers {:content-type "application/json"
+                             :server       "clj-http.fake"}
+
+                   :raw     {:body                  {:embedded   {}
+                                                     :links      {}
+                                                     :properties {:test "test"}}
+                             :headers               {:content-type "application/json"
+                                                     :server       "clj-http.fake"}
+                             :opts                  {:as      :text
+                                                     :body    (json/generate-string test-resource)
+                                                     :headers {"Accept"       "application/hal+json"
+                                                               "Content-Type" "application/json"}
+                                                     :method  :post
+                                                     :url     "https://service.example.com"}
+                             :orig-content-encoding nil
+                             :status                201}
+                   :status  201
+                   :url     "https://service.example.com"}))))))))

--- a/test/halboy/http/default_test.clj
+++ b/test/halboy/http/default_test.clj
@@ -29,5 +29,4 @@
                                    :url     "https://service.example.com"}
                          :status  201}
                :status  201
-               :url     "https://service.example.com"}
-              ))))))
+               :url     "https://service.example.com"}))))))

--- a/test/halboy/navigator_clj_http_client_test.clj
+++ b/test/halboy/navigator_clj_http_client_test.clj
@@ -1,12 +1,13 @@
-(ns halboy.navigator-test
-  (:use org.httpkit.fake)
+(ns halboy.navigator-clj-http-client-test
+
   (:require [clojure.test :refer :all]
             [clojure.string :refer [capitalize]]
             [halboy.navigator :as navigator]
             [halboy.resource :as hal]
             [halboy.json :as json]
-            [halboy.support.http-kit-api :as stubs]
-            [halboy.resource :as hal])
+            [halboy.http.clj-http :as clj-http]
+            [halboy.support.clj-http-api :as stubs]
+            [clj-http.fake :refer [try-intercept with-fake-routes-in-isolation]])
   (:import [java.net URL]
            [clojure.lang ExceptionInfo]))
 
@@ -21,14 +22,18 @@
     (hal/add-link :self {:href (create-url base-url (format "/users/%s" name))})
     (hal/add-property :name (capitalize name))))
 
-(deftest halboy-navigator
+(def default-settings
+  {:client (clj-http/new-http-client)})
+
+
+(deftest halboy-navigator-clj-http-client
   (testing "should be able to retrieve the settings"
-    (with-fake-http
+    (with-fake-routes-in-isolation
       (stubs/on-discover
         base-url
         :users {:href      "/users{?admin}"
                 :templated true})
-      (let [options (-> (navigator/discover base-url)
+      (let [options (-> (navigator/discover base-url default-settings)
                       (navigator/settings))]
         (is (true? (:follow-redirects options)))
         (is (empty? (:headers options)))
@@ -36,27 +41,30 @@
 
   (testing "should be able to pass options to the HTTP client"
     (let [resource-url (create-url base-url "/users/thomas")]
-      (with-fake-http
-        (concat
+      (with-fake-routes-in-isolation
+        (merge
           (stubs/on-discover
             base-url
             :user {:href      "/users/{id}"
                    :templated true})
           (stubs/on-delete-with-headers
             resource-url
-            {"Content-Type" "application/json"
-             "Accept"       "application/hal+json"
-             "My-Header"    "some-value"}
+            {"Content-Type"    "application/json"
+             "Accept"          "application/hal+json"
+             "accept-encoding" "gzip, deflate"
+             "My-Header"       "some-value"}
             {:status 204}))
         (let [result (->
-                       (navigator/discover base-url {:http {:headers {"My-Header" "some-value"}}})
+                       (navigator/discover base-url
+                         (merge default-settings
+                           {:http {:headers {"My-Header" "some-value"}}}))
                        (navigator/delete :user {:id "thomas"}))
               status (navigator/status result)]
           (is (= 204 status))))))
 
   (testing "should be able to navigate through links in an API"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?admin}"
@@ -70,7 +78,7 @@
                        :users (create-user "sue")
                        :users (create-user "mary"))
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/get :users))
             status (navigator/status result)
             users (-> (navigator/resource result)
@@ -82,17 +90,17 @@
               (map #(hal/get-property % :name) users))))))
 
   (testing "should throw an error when trying to get a link which does not exist"
-    (with-fake-http
+    (with-fake-routes-in-isolation
       (stubs/on-discover base-url)
       (is (thrown-with-msg?
             ExceptionInfo
             #"Attempting to follow a link which does not exist"
-            (-> (navigator/discover base-url)
+            (-> (navigator/discover base-url default-settings)
               (navigator/get :users))))))
 
   (testing "should throw an error when the response is not JSON"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?admin}"
@@ -104,18 +112,19 @@
       (is (thrown-with-msg?
             ExceptionInfo
             #"Response body was not valid JSON"
-            (-> (navigator/discover base-url)
+            (-> (navigator/discover base-url default-settings)
               (navigator/get :users))))))
 
   (testing "should be able to navigate through links with query params"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?admin}"
                   :templated true})
         (stubs/on-get
-          (create-url base-url "/users") {:admin "true"}
+          (create-url base-url "/users")
+          {:admin "true"}
           {:status 200
            :body   (-> (hal/new-resource "/users")
                      (hal/add-resources
@@ -123,7 +132,7 @@
                        :users (create-user "sue")
                        :users (create-user "mary"))
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/get :users {:admin true}))
             status (navigator/status result)
             users (-> (navigator/resource result)
@@ -135,22 +144,23 @@
               (map #(hal/get-property % :name) users))))))
 
   (testing "should be able to navigate through links with multiple query params"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?admin,owner}"
                   :templated true})
         (stubs/on-get
-          (create-url base-url "/users") {:admin "true"
-                                          :owner "false"}
+          (create-url base-url "/users")
+          {:admin "true"
+           :owner "false"}
           {:status 200
            :body   (-> (hal/new-resource "/users")
                      (hal/add-resources
                        :users (create-user "fred")
                        :users (create-user "sue"))
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/get :users {:admin true
                                             :owner false}))
             status (navigator/status result)
@@ -163,8 +173,8 @@
               (map #(hal/get-property % :name) users))))))
 
   (testing "should be able to navigate with a mixture of template and query params"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :friends {:href      "/users/{id}/friends{?mutual}"
@@ -178,7 +188,7 @@
                        :users (create-user "sue")
                        :users (create-user "mary"))
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/get :friends {:id "thomas" :mutual true}))
             status (navigator/status result)
             users (-> (navigator/resource result)
@@ -190,8 +200,8 @@
               (map #(hal/get-property % :name) users))))))
 
   (testing "should be able to create resources in an API"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href "/users"})
@@ -205,7 +215,7 @@
            :body   (-> (hal/new-resource "/users/thomas")
                      (hal/add-property :name "Thomas")
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/post :users {:name "Thomas"}))
             status (navigator/status result)
             new-user (navigator/resource result)]
@@ -214,8 +224,8 @@
         (is (= "Thomas" (hal/get-property new-user :name))))))
 
   (testing "should be able to remove resources in an API"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :user {:href      "/users/{id}"
@@ -223,14 +233,14 @@
         (stubs/on-delete
           (create-url base-url "/users/thomas")
           {:status 204}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/delete :user {:id "thomas"}))
             status (navigator/status result)]
         (is (= 204 status)))))
 
   (testing "should be able to update resources in an API"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :user {:href      "/users/{id}"
@@ -246,7 +256,7 @@
                      (hal/add-property :name "Thomas")
                      (hal/add-property :surname "Svensson")
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/patch :user {:id "thomas"} {:surname "Svensson"}))
             status (navigator/status result)
             new-user (navigator/resource result)]
@@ -256,8 +266,8 @@
         (is (= "Svensson" (hal/get-property new-user :surname))))))
 
   (testing "should handle query params on post"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?first,second}"
@@ -273,7 +283,7 @@
                      (hal/add-link :self "/users/thomas")
                      (hal/add-property :name "Thomas")
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/post :users {:name "Thomas"}))
             status (navigator/status result)
             new-user (navigator/resource result)]
@@ -282,8 +292,8 @@
         (is (= "Thomas" (hal/get-property new-user :name))))))
 
   (testing "should handle query params on delete"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?name}"
@@ -291,14 +301,14 @@
         (stubs/on-delete
           (create-url base-url "/users") {:name "thomas"}
           {:status 204}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/delete :users {:name "thomas"}))
             status (navigator/status result)]
         (is (= 204 status)))))
 
   (testing "should be able to use template params when creating resources"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :useritems {:href      "/users/{id}/items"
@@ -313,7 +323,7 @@
            :body   (-> (hal/new-resource "/users/thomas/items/1")
                      (hal/add-property :name "Sponge")
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/post :useritems {:id "thomas"} {:name "Sponge"}))
             status (navigator/status result)
             new-item (navigator/resource result)]
@@ -322,8 +332,8 @@
         (is (= "Sponge" (hal/get-property new-item :name))))))
 
   (testing "should not follow location headers when the status is not 201"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?admin}"
@@ -332,14 +342,14 @@
           (create-url base-url "/users")
           {:name "Thomas"}
           {:status 400}))
-      (let [status (-> (navigator/discover base-url)
+      (let [status (-> (navigator/discover base-url default-settings)
                      (navigator/post :users {:name "Thomas"})
                      (navigator/status))]
         (is (= 400 status)))))
 
   (testing "should not follow location headers when the options say not to"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href      "/users{?admin}"
@@ -348,7 +358,7 @@
           (create-url base-url "/users")
           {:name "Thomas"}
           "/users/thomas"))
-      (let [result (-> (navigator/discover base-url {:follow-redirects false})
+      (let [result (-> (navigator/discover base-url (merge default-settings {:follow-redirects false}))
                      (navigator/post :users {:name "Thomas"}))
             status (navigator/status result)]
 
@@ -358,8 +368,8 @@
               (navigator/get-header result :location))))))
 
   (testing "should be able to continue the conversation even if we do not follow redirects"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href "/users"})
@@ -373,7 +383,7 @@
            :body   (-> (hal/new-resource "/users/thomas")
                      (hal/add-property :name "Thomas")
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url {:follow-redirects false})
+      (let [result (-> (navigator/discover base-url (merge default-settings {:follow-redirects false}))
                      (navigator/post :users {:name "Thomas"})
                      (navigator/follow-redirect))
             status (navigator/status result)
@@ -383,8 +393,8 @@
         (is (= "Thomas" (hal/get-property new-user :name))))))
 
   (testing "should throw when trying to follow a redirect without a location header"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :users {:href "/users"})
@@ -394,13 +404,13 @@
           {:status  201
            :headers {}}))
       (is (thrown? ExceptionInfo
-            (-> (navigator/discover base-url {:follow-redirects false})
+            (-> (navigator/discover base-url (merge default-settings {:follow-redirects false}))
               (navigator/post :users {:name "Thomas"})
               (navigator/follow-redirect))))))
 
   (testing "should be able to put to a resource"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :user {:href      "/users/{id}"
@@ -412,7 +422,7 @@
            :body   (-> (hal/new-resource "/users/thomas")
                      (hal/add-property :name "Thomas")
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/put :user {:id "thomas"} {:name "Thomas"}))
             status (navigator/status result)
             user (navigator/resource result)]
@@ -421,8 +431,8 @@
         (is (= "Thomas" (hal/get-property user :name))))))
 
   (testing "should follow redirects when putting to a resource returns a 201"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :user {:href      "/users/{id}"
@@ -437,7 +447,7 @@
            :body   (-> (hal/new-resource "/users/thomas")
                      (hal/add-property :name "Thomas")
                      (json/resource->json))}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/put :user {:id "thomas"} {:name "Thomas"}))
             status (navigator/status result)
             user (navigator/resource result)]
@@ -446,8 +456,8 @@
         (is (= "Thomas" (hal/get-property user :name))))))
 
   (testing "should be able to head to a resource"
-    (with-fake-http
-      (concat
+    (with-fake-routes-in-isolation
+      (merge
         (stubs/on-discover
           base-url
           :user {:href      "/users/{id}"
@@ -455,7 +465,7 @@
         (stubs/on-head
           (create-url base-url "/users/thomas")
           {:status 200}))
-      (let [result (-> (navigator/discover base-url)
+      (let [result (-> (navigator/discover base-url default-settings)
                      (navigator/head :user {:id "thomas"}))
             status (navigator/status result)]
 
@@ -463,8 +473,8 @@
 
   (testing "should be able to set header for delete"
     (let [resource-url (create-url base-url "/users/thomas")]
-      (with-fake-http
-        (concat
+      (with-fake-routes-in-isolation
+        (merge
           (stubs/on-discover
             base-url
             :user {:href      "/users/{id}"
@@ -473,10 +483,11 @@
             resource-url
             {"Content-Type"        "application/json"
              "Accept"              "application/hal+json"
+             "accept-encoding"     "gzip, deflate"
              "X-resource-location" resource-url}
             {:status 204}))
         (let [result (->
-                       (navigator/discover base-url)
+                       (navigator/discover base-url default-settings)
                        (navigator/set-header "X-resource-location" resource-url)
                        (navigator/delete :user {:id "thomas"}))
               status (navigator/status result)]
@@ -484,8 +495,8 @@
 
   (testing "should be able to set header for post"
     (let [resource-url (create-url base-url "/users/thomas")]
-      (with-fake-http
-        (concat
+      (with-fake-routes-in-isolation
+        (merge
           (stubs/on-discover
             base-url
             :users {:href "/users"})
@@ -493,10 +504,11 @@
             (create-url base-url "/users")
             {"Content-Type"        "application/json"
              "Accept"              "application/hal+json"
+             "accept-encoding"     "gzip, deflate"
              "X-resource-location" resource-url}
             {:name "Thomas"}
             {:status 201}))
-        (let [result (-> (navigator/discover base-url {:follow-redirects false})
+        (let [result (-> (navigator/discover base-url  (merge default-settings {:follow-redirects false}))
                        (navigator/set-header "X-resource-location" resource-url)
                        (navigator/post :users {:name "Thomas"}))
               status (navigator/status result)]
@@ -504,7 +516,7 @@
           (is (= 201 status))))))
 
   (testing "should be able to resume conversations"
-    (with-fake-http
+    (with-fake-routes-in-isolation
       (stubs/on-get
         (create-url base-url "/users")
         {:status 200
@@ -517,7 +529,7 @@
       (let [resource (-> (hal/new-resource base-url)
                        (hal/add-link :users {:href      "/users{?admin}"
                                              :templated true}))
-            result (-> (navigator/resume resource)
+            result (-> (navigator/resume resource default-settings)
                      (navigator/get :users))
             status (navigator/status result)
             users (-> (navigator/resource result)
@@ -529,7 +541,7 @@
               (map #(hal/get-property % :name) users))))))
 
   (testing "should be able to hint at the location when the self link is not absolute"
-    (with-fake-http
+    (with-fake-routes-in-isolation
       (stubs/on-get
         (create-url base-url "/users")
         {:status 200
@@ -542,7 +554,8 @@
       (let [resource (-> (hal/new-resource "/")
                        (hal/add-link :users {:href      "/users{?admin}"
                                              :templated true}))
-            result (-> (navigator/resume resource {:resume-from base-url})
+            result (-> (navigator/resume resource (merge default-settings
+                                                    {:resume-from base-url}))
                      (navigator/get :users))
             status (navigator/status result)
             users (-> (navigator/resource result)
@@ -557,11 +570,13 @@
           with a resource that lacks a self link"
     (is (thrown? ExceptionInfo
           (navigator/resume
-            (hal/new-resource)))))
+            (hal/new-resource)
+            default-settings))))
 
   (testing "should throw an error when trying to resume a conversation
           with a resource with a relative self link, and no :resume-from option"
     (is (thrown? ExceptionInfo
           (navigator/resume
             (-> (hal/new-resource)
-              (hal/add-href :self "/users")))))))
+              (hal/add-href :self "/users"))
+            default-settings)))))

--- a/test/halboy/support/clj_http_api.clj
+++ b/test/halboy/support/clj_http_api.clj
@@ -1,0 +1,130 @@
+(ns halboy.support.clj-http-api
+  (:require [clojure.walk :refer [stringify-keys]]
+            [cheshire.core :as json]
+            [halboy.resource :refer [new-resource add-links]]
+            [halboy.json :refer [resource->json]]
+            [clj-http.util :as http-util]))
+
+(defn- fake-mismatch [req]
+  (throw (ex-info "fake does not match" {:request req})))
+
+(defn- headers-match? [req headers]
+  (= (:headers req)
+    headers))
+
+(defn- body-match? [req body]
+  (=
+    (http-util/force-string (:body req) "utf-8")
+    (json/generate-string body)))
+
+(defn- redirect-to [location]
+  {:status  201
+   :headers {:location location}})
+
+(defn on-discover [url & kvs]
+  {url
+   {:get
+    (fn [_]
+      {:status 200
+       :body   (-> (new-resource)
+                 ((partial apply add-links) kvs)
+                 resource->json)})}})
+
+(defn on-head
+  ([url response]
+   {url
+    {:head (fn [_] response)}}))
+
+(defn on-get
+  ([url response]
+   {url
+    {:get (fn [_] response)}})
+  ([url params response]
+   {{:address      url
+     :query-params params}
+    (fn [_] response)}))
+
+(defn on-post
+  ([url response]
+   {url
+    {:post (fn [_] response)}})
+  ([url body response]
+   {url
+    {:post
+     (fn [req]
+       (when-not (body-match? req body) (fake-mismatch req))
+       response)}}))
+
+(defn on-post-with-headers
+  ([url headers response]
+   {url
+    {:post
+     (fn [req]
+       (when-not (headers-match? req headers) (fake-mismatch req))
+       response)}})
+  ([url headers body response]
+   {url
+    {:post
+     (fn [req]
+       (when-not (and (body-match? req body) (headers-match? req headers))
+         (fake-mismatch req))
+       response)}}))
+
+(defn on-post-redirect
+  ([url location]
+   (on-post url (redirect-to location)))
+  ([url body location]
+   (on-post url body (redirect-to location))))
+
+(defn on-put
+  ([url response]
+   {{:address url}
+    {:put (fn [_] response)}})
+  ([url body response]
+   {{:address url}
+    {:put
+     (fn [req]
+       (when-not (body-match? req body) (fake-mismatch req))
+       response)}}))
+
+(defn on-put-redirect
+  ([url location]
+   (on-put url (redirect-to location)))
+  ([url body location]
+   (on-put url body (redirect-to location))))
+
+(defn on-patch
+  ([url response]
+   {{:address url}
+    {:patch (fn [_] response)}})
+  ([url body response]
+   {{:address url}
+    {:patch
+     (fn [req]
+       (when-not (body-match? req body) (fake-mismatch req))
+       response)}}))
+
+(defn on-patch-redirect
+  ([url location]
+   (on-patch url (redirect-to location)))
+  ([url body location]
+   (on-patch url body (redirect-to location))))
+
+(defn on-delete
+  ([url response]
+   {url
+    {:delete (fn [_] response)}})
+  ([url params response]
+   {{:address      url
+     :method       :delete
+     :query-params params}
+    (fn [_] response)}))
+
+(defn on-delete-with-headers
+  [url headers response]
+  {url
+   {:delete
+    (fn [req]
+      (when-not (headers-match? req headers) (fake-mismatch req))
+      response)}})
+

--- a/test/halboy/support/http_kit_api.clj
+++ b/test/halboy/support/http_kit_api.clj
@@ -1,4 +1,4 @@
-(ns halboy.support.api
+(ns halboy.support.http-kit-api
   (:require [clojure.walk :refer [stringify-keys]]
             [cheshire.core :as json]
             [halboy.resource :refer [new-resource add-links]]


### PR DESCRIPTION
Hello, 

This is a proposal PR which brings in `clj-http` as an alternative, pre-configured http client (in synchronous mode). 
It also adds tests to make sure it's factory method clj-http-client (new-http-client) works as intended and all existing navigator tests are passing. 

I am not 100% satisfied yet, as the navigator tests are now duplicated (due to stubs differing) so would like to see if you might have any ideas how to seamlessly reconcile? 

P.S. In the preview, you might need to unfold test/halboy/navigator_clj_http_client_test.clj as it's too big, so doesn't show up.

# Rationale for the addition
- http-kit uses a home baked client (written from scratch in Java), this makes it incompatible with any auto instrumentation APM tools (e.g. https://docs.datadoghq.com/tracing/compatibility_requirements/java/#networking-framework-compatibility) 
- http-kit is written from scratch, has lots of TODOs (it's HttpClient Java class) and is riddled by HTTPS negotiation and idling bugs (experienced a couple in production)
- clj-http uses Apache Http (HttpComponents) and supports both the sync and async (NIO) client and is supported by all auto-instrumentation tools (this is useful for distributed tracing for example)

# Work done
- [x] Created clj-http-fake equivalent stubs for navigator
- [x] Created clj-http low level tests
- [x] Created equivalent navigator tests (copied all existing tests)
- [x] Figure out a way how to make existing http-kit stubs work with clj-http-fake stubs, which are a little different (url->fn instead of vector of two objects)
- [ ] Use clj-test `are` and iterate over available clients using some stubs adapter, so not to duplicate all tests in navigator_test.clj 

UPDATE:
I have created a little library which comprises of a macro that can evaluate the http-kit.fake stub and convert it into an equivalent clj-http.fake stub, with tests and all: https://github.com/danielzurawski/clj-http-fakes-adapter


