### PR TITLE
Throw more informative error if write-url response is invalid

### DIFF
--- a/test/halboy/navigator_test.clj
+++ b/test/halboy/navigator_test.clj
@@ -445,6 +445,20 @@
         (is (= 200 status))
         (is (= "Thomas" (hal/get-property user :name))))))
 
+  (testing "should throw if the response indicates redirect but body does not contain url"
+    (with-fake-http
+      (concat
+        (stubs/on-discover
+          base-url
+          :user {:href      "/users/{id}"
+                 :templated true})
+        [{:method :put
+         :url (create-url base-url "/users/thomas")}
+         {:status 201, :body "{}"}])
+      (is (thrown? ExceptionInfo 
+           (-> (navigator/discover base-url)
+             (navigator/put :user {:id "thomas"} {:name "Thomas"}))))))
+
   (testing "should be able to head to a resource"
     (with-fake-http
       (concat


### PR DESCRIPTION
I ran into an issue when developing with halboy where I was PUTing to an endpoint which returned a `201` but there was no `url` in the response body. This was hard to debug because it resulted in a `NullPointerException` fairly deep in Halboy's internals. This PR adds a check in `write-url` which throws an exception with a more informative error message to make debugging easier in this case.