### PR TITLE
Respect HTTP Content-Type header and other various updates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,8 @@
                  [uritemplate-clj "1.2.1"]
                  [org.clojure/core.cache "0.7.1"]
                  [org.bovinegenius/exploding-fish "0.3.6"]]
-  :plugins [[lein-eftest "0.5.2"]]
+  :plugins [[lein-eftest "0.5.9"]]
   :profiles {:shared {:dependencies [[nrepl "0.6.0"]]}
              :test   [:shared {:dependencies [[http-kit.fake "0.2.2"]
-                                              [eftest "0.5.2"]]}]}
+                                              [eftest "0.5.9"]]}]}
   :eftest {:multithread? false})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject halboy "5.1.1"
+(defproject halboy "5.2.1"
   :description "a hypermedia parser and navigator"
   :license {:name "MIT License"
             :url  "https://opensource.org/licenses/MIT"}

--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,15 @@
   :license {:name "MIT License"
             :url  "https://opensource.org/licenses/MIT"}
   :url "https://github.com/jimmythompson/halboy"
-  :dependencies [[org.clojure/clojure "1.9.0-alpha16"]
-                 [http-kit "2.3.0"]
-                 [cheshire "5.8.0"]
-                 [medley "1.0.0"]
-                 [uritemplate-clj "1.2.1"]
-                 [org.clojure/core.cache "0.7.1"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [http-kit "2.5.3"]
+                 [cheshire "5.10.2"]
+                 [medley "1.3.0"]
+                 [uritemplate-clj "1.3.1"]
+                 [org.clojure/core.cache "1.0.225"]
                  [org.bovinegenius/exploding-fish "0.3.6"]]
   :plugins [[lein-eftest "0.5.9"]]
-  :profiles {:shared {:dependencies [[nrepl "0.6.0"]]}
+  :profiles {:shared {:dependencies [[nrepl "0.9.0"]]}
              :test   [:shared {:dependencies [[http-kit.fake "0.2.2"]
                                               [eftest "0.5.9"]]}]}
   :eftest {:multithread? false})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject halboy "5.2.1"
+(defproject halboy "6.0.0"
   :description "a hypermedia parser and navigator"
   :license {:name "MIT License"
             :url  "https://opensource.org/licenses/MIT"}

--- a/src/halboy/data.clj
+++ b/src/halboy/data.clj
@@ -2,3 +2,8 @@
 
 (defn transform-values [m f]
   (into {} (for [[k v] m] [k (f v)])))
+
+(defn update-if-present [m ks fn]
+  (if (get-in m ks)
+    (update-in m ks #(fn %))
+    m))

--- a/src/halboy/http/cachable.clj
+++ b/src/halboy/http/cachable.clj
@@ -1,6 +1,6 @@
 (ns halboy.http.cachable
   (:require
-    [clojure.walk :refer [stringify-keys keywordize-keys]]
+    [clojure.walk :refer [stringify-keys]]
     [org.httpkit.client :as http]
     [clojure.core.cache :as cache]
     [halboy.argutils :refer [deep-merge]]
@@ -12,16 +12,6 @@
   {:as      :text
    :headers {"Content-Type" "application/json"
              "Accept"       "application/hal+json"}})
-
-(defn http-method->fn [method]
-  (get-in
-    {:head   http/head
-     :get    http/get
-     :post   http/post
-     :put    http/put
-     :patch  http/patch
-     :delete http/delete}
-    [method]))
 
 (defn- with-default-options [m]
   (deep-merge default-http-options m))
@@ -37,16 +27,15 @@
 
 (deftype CachableHttpClient [cache-store]
   protocol/HttpClient
-  (exchange [_ {:keys [url method] :as request}]
+  (exchange [_ request]
     (let [request (-> request
                       (with-default-options)
                       (with-transformed-params)
                       (haljson/if-json-encode-body))
-          http-fn (http-method->fn method)
           response (if (cache/has? @cache-store request)
                      (get (cache/hit @cache-store request) request)
                      (let [updated-cache (swap! cache-store #(cache/miss % request
-                                                                         @(http-fn url request)))]
+                                                                         @(http/request request)))]
                        (get updated-cache request)))]
       (-> response
           (haljson/if-json-parse-response)

--- a/src/halboy/http/cachable.clj
+++ b/src/halboy/http/cachable.clj
@@ -1,22 +1,17 @@
 (ns halboy.http.cachable
   (:require
     [clojure.walk :refer [stringify-keys keywordize-keys]]
-    [cheshire.core :as json]
     [org.httpkit.client :as http]
     [clojure.core.cache :as cache]
     [halboy.argutils :refer [deep-merge]]
-    [halboy.http.protocol :as protocol])
-  (:import [com.fasterxml.jackson.core JsonParseException]))
+    [halboy.data :refer [update-if-present]]
+    [halboy.json :as haljson]
+    [halboy.http.protocol :as protocol]))
 
 (def default-http-options
   {:as      :text
    :headers {"Content-Type" "application/json"
              "Accept"       "application/hal+json"}})
-
-(defn- update-if-present [m ks fn]
-  (if (get-in m ks)
-    (update-in m ks #(fn %))
-    m))
 
 (defn http-method->fn [method]
   (get-in
@@ -30,20 +25,6 @@
 
 (defn- with-default-options [m]
   (deep-merge default-http-options m))
-
-(defn- with-json-body [m]
-  (update-if-present m [:body] json/generate-string))
-
-(defn- parse-json-response [response]
-  (try
-    (update-if-present
-      response [:body]
-      #(-> (json/parse-string %)
-         (keywordize-keys)))
-    (catch JsonParseException ex
-      (assoc response
-        :error {:code :not-valid-json
-                :cause ex}))))
 
 (defn- with-transformed-params [m]
   (update-if-present m [:query-params] stringify-keys))
@@ -60,18 +41,15 @@
     (let [request (-> request
                       (with-default-options)
                       (with-transformed-params)
-                      (with-json-body))
+                      (haljson/if-json-encode-body))
           http-fn (http-method->fn method)
           response (if (cache/has? @cache-store request)
                      (get (cache/hit @cache-store request) request)
                      (let [updated-cache (swap! cache-store #(cache/miss % request
                                                                          @(http-fn url request)))]
-                       (get updated-cache request))
-                     )
-          ]
-
+                       (get updated-cache request)))]
       (-> response
-          (parse-json-response)
+          (haljson/if-json-parse-response)
           (format-for-halboy)))))
 
 (defn new-http-client

--- a/src/halboy/http/cachable.clj
+++ b/src/halboy/http/cachable.clj
@@ -9,7 +9,7 @@
     [halboy.http.protocol :as protocol]))
 
 (def default-http-options
-  {:as      :text
+  {:as      :auto
    :headers {"Content-Type" "application/json"
              "Accept"       "application/hal+json"}})
 

--- a/src/halboy/http/cachable.clj
+++ b/src/halboy/http/cachable.clj
@@ -9,7 +9,7 @@
     [halboy.http.protocol :as protocol]))
 
 (def default-http-options
-  {:as      :auto
+  {:as      :stream
    :headers {"Content-Type" "application/json"
              "Accept"       "application/hal+json"}})
 
@@ -38,7 +38,7 @@
                                                                          @(http/request request)))]
                        (get updated-cache request)))]
       (-> response
-          (haljson/if-json-parse-response)
+          (haljson/coerce-response-type)
           (format-for-halboy)))))
 
 (defn new-http-client

--- a/src/halboy/http/cachable.clj
+++ b/src/halboy/http/cachable.clj
@@ -5,8 +5,8 @@
     [clojure.core.cache :as cache]
     [halboy.argutils :refer [deep-merge]]
     [halboy.data :refer [update-if-present]]
-    [halboy.json :as haljson]
-    [halboy.http.protocol :as protocol]))
+    [halboy.http.protocol :as protocol]
+    [halboy.types :as types]))
 
 (def default-http-options
   {:as      :stream
@@ -31,14 +31,14 @@
     (let [request (-> request
                       (with-default-options)
                       (with-transformed-params)
-                      (haljson/if-json-encode-body))
+                      (types/if-json-encode-body))
           response (if (cache/has? @cache-store request)
                      (get (cache/hit @cache-store request) request)
                      (let [updated-cache (swap! cache-store #(cache/miss % request
                                                                          @(http/request request)))]
                        (get updated-cache request)))]
       (-> response
-          (haljson/coerce-response-type)
+          (types/coerce-response-type)
           (format-for-halboy)))))
 
 (defn new-http-client

--- a/src/halboy/http/default.clj
+++ b/src/halboy/http/default.clj
@@ -8,7 +8,7 @@
     [halboy.json :as haljson]))
 
 (def default-http-options
-  {:as      :text
+  {:as      :auto
    :headers {"Content-Type" "application/json"
              "Accept"       "application/hal+json"}})
 

--- a/src/halboy/http/default.clj
+++ b/src/halboy/http/default.clj
@@ -8,7 +8,7 @@
     [halboy.json :as haljson]))
 
 (def default-http-options
-  {:as      :auto
+  {:as      :stream
    :headers {"Content-Type" "application/json"
              "Accept"       "application/hal+json"}})
 
@@ -32,7 +32,7 @@
                       (with-transformed-params)
                       (haljson/if-json-encode-body))]
       (-> @(http/request request)
-          (haljson/if-json-parse-response)
+          (haljson/coerce-response-type)
           (format-for-halboy)))))
 
 (defn new-http-client []

--- a/src/halboy/http/default.clj
+++ b/src/halboy/http/default.clj
@@ -5,7 +5,7 @@
     [halboy.argutils :refer [deep-merge]]
     [halboy.data :refer [update-if-present]]
     [halboy.http.protocol :as protocol]
-    [halboy.json :as haljson]))
+    [halboy.types :as types]))
 
 (def default-http-options
   {:as      :stream
@@ -30,9 +30,9 @@
     (let [request (-> request
                       (with-default-options)
                       (with-transformed-params)
-                      (haljson/if-json-encode-body))]
+                      (types/if-json-encode-body))]
       (-> @(http/request request)
-          (haljson/coerce-response-type)
+          (types/coerce-response-type)
           (format-for-halboy)))))
 
 (defn new-http-client []

--- a/src/halboy/json.clj
+++ b/src/halboy/json.clj
@@ -1,11 +1,9 @@
 (ns halboy.json
-  (:require
-    [clojure.walk :refer [keywordize-keys]]
-    [halboy.data :refer [transform-values update-if-present]]
-    [halboy.resource :as hal]
-    [cheshire.core :as json]
-    [clojure.string :as str])
-  (:import (com.fasterxml.jackson.core JsonParseException)))
+  (:require [cheshire.core :as json]
+            [halboy.resource :as hal]
+            [clojure.walk :refer [keywordize-keys]]
+            [halboy.data :refer [transform-values]])
+  (:import [com.fasterxml.jackson.core JsonParseException]))
 
 (declare map->resource resource->map)
 
@@ -13,8 +11,7 @@
   (:_links m {}))
 
 (defn- extract-properties [m]
-  (-> (dissoc m :_links :_embedded)
-      (or {})))
+  (or (dissoc m :_links :_embedded) {}))
 
 (defn- map->embedded-resource [m]
   (if (map? m)
@@ -60,8 +57,13 @@
         map->resource)
     (catch JsonParseException e
       (throw (ex-info "Failed to parse json"
-                      {:exception e
-                       :string    s})))))
+               {:exception e
+                :string    s})))))
+
+(defn resource->json
+  "Transforms a resource into a HAL+JSON string"
+  [resource]
+  (json/generate-string (resource->map resource)))
 
 (defn resource->map
   "Transforms a resource into a map representing a HAL+JSON
@@ -71,59 +73,3 @@
     (links->map resource)
     (embedded->map resource)
     (:properties resource)))
-
-(defn resource->json
-  "Transforms a resource into a HAL+JSON string"
-  [resource]
-  (-> (resource->map resource)
-      json/generate-string))
-
-(defn parse-json-response [response]
-  (try
-    (update-if-present
-      response [:body]
-      #(-> (json/parse-string %)
-         (keywordize-keys)))
-    (catch JsonParseException ex
-      (assoc response
-        :error {:code :not-valid-json
-                :cause ex}))))
-
-(defn extract-content-type [response]
-  (let [content-type (get-in response [:headers :content-type] "application/json")
-        [media-type properties] (str/split content-type #";" 2)]
-    {:media-type   (str/trim media-type)
-     :charset      (str/upper-case (nth (re-find #"charset=([A-Za-z-0-9-]+)" (or properties "")) 1 "UTF-8"))
-     :content-type content-type}))
-
-(def ^:private json-media-type?
-  #{"application/json"
-    "application/hal+json"})
-
-(defn- json-content-type? [response]
-  (let [content-type (extract-content-type response)]
-    (json-media-type? (:media-type content-type))))
-
-(defn with-json-body [m]
-  (update-if-present m [:body] json/generate-string))
-
-(defn if-json-encode-body [request]
-  (if (json-content-type? request)
-    (with-json-body request)
-    request))
-
-(defn stream-body->string-body [response ^String charset]
-  (if (or (string? (:body response)) (nil? (:body response)))
-    response
-    (update response :body #(String. ^bytes (.bytes %) charset))))
-
-(defn coerce-response-type [response]
-  (let [{:keys [media-type charset]} (extract-content-type response)]
-    (cond
-      (str/includes? media-type "json")
-      (parse-json-response (stream-body->string-body response charset))
-      (or (str/starts-with? media-type "text/")
-        (str/includes? media-type "xml"))
-      (stream-body->string-body response charset)
-      :else
-      response)))

--- a/src/halboy/json.clj
+++ b/src/halboy/json.clj
@@ -89,24 +89,41 @@
         :error {:code :not-valid-json
                 :cause ex}))))
 
+(defn extract-content-type [response]
+  (let [content-type (get-in response [:headers :content-type] "application/json")
+        [media-type properties] (str/split content-type #";" 2)]
+    {:media-type   (str/trim media-type)
+     :charset      (str/upper-case (nth (re-find #"charset=([A-Za-z-0-9-]+)" (or properties "")) 1 "UTF-8"))
+     :content-type content-type}))
+
 (def ^:private json-media-type?
   #{"application/json"
     "application/hal+json"})
 
 (defn- json-content-type? [response]
-  (let [content-type (get-in response [:headers :content-type] "application/json")
-        media-type (str/trim (first (str/split content-type #";" 2)))]
-    (json-media-type? media-type)))
+  (let [content-type (extract-content-type response)]
+    (json-media-type? (:media-type content-type))))
 
-(defn if-json-parse-response [response]
-  (if (json-content-type? response)
-    (parse-json-response response)
-    response))
-
-(defn- with-json-body [m]
+(defn with-json-body [m]
   (update-if-present m [:body] json/generate-string))
 
 (defn if-json-encode-body [request]
   (if (json-content-type? request)
     (with-json-body request)
     request))
+
+(defn stream-body->string-body [response ^String charset]
+  (if (or (string? (:body response)) (nil? (:body response)))
+    response
+    (update response :body #(String. ^bytes (.bytes %) charset))))
+
+(defn coerce-response-type [response]
+  (let [{:keys [media-type charset]} (extract-content-type response)]
+    (cond
+      (str/includes? media-type "json")
+      (parse-json-response (stream-body->string-body response charset))
+      (or (str/starts-with? media-type "text/")
+        (str/includes? media-type "xml"))
+      (stream-body->string-body response charset)
+      :else
+      response)))

--- a/src/halboy/navigator.clj
+++ b/src/halboy/navigator.clj
@@ -1,12 +1,13 @@
 (ns halboy.navigator
   (:refer-clojure :exclude [get])
   (:require [halboy.resource :as hal]
-            [halboy.json :as haljson]
             [halboy.http.default :as client]
             [halboy.http.protocol :as http]
             [halboy.params :as params]
             [halboy.argutils :refer [deep-merge]]
-            [halboy.url :as url]))
+            [halboy.url :as url]
+            [halboy.types :as types]
+            [halboy.json :as haljson]))
 
 (def default-settings
   {:client           (client/new-http-client)
@@ -57,7 +58,7 @@
     #_"application/hal+xml"})
 
 (defn- hal-response? [response]
-  (let [content-type (haljson/extract-content-type response)]
+  (let [content-type (types/extract-content-type response)]
     (hal-media-type? (:media-type content-type))))
 
 (defn- response->Navigator [response settings]

--- a/src/halboy/navigator.clj
+++ b/src/halboy/navigator.clj
@@ -1,7 +1,6 @@
 (ns halboy.navigator
   (:refer-clojure :exclude [get])
-  (:require [clojure.string :as str]
-            [halboy.resource :as hal]
+  (:require [halboy.resource :as hal]
             [halboy.json :as haljson]
             [halboy.http.default :as client]
             [halboy.http.protocol :as http]
@@ -58,9 +57,8 @@
     #_"application/hal+xml"})
 
 (defn- hal-response? [response]
-  (let [content-type (get-in response [:headers :content-type] "application/json")
-        media-type (str/trim (first (str/split content-type #";" 2)))]
-    (hal-media-type? media-type)))
+  (let [content-type (haljson/extract-content-type response)]
+    (hal-media-type? (:media-type content-type))))
 
 (defn- response->Navigator [response settings]
   (if (failed? response)

--- a/src/halboy/navigator.clj
+++ b/src/halboy/navigator.clj
@@ -1,9 +1,7 @@
 (ns halboy.navigator
   (:refer-clojure :exclude [get])
-  (:require [clojure.walk :refer [keywordize-keys stringify-keys]]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [halboy.resource :as hal]
-            [halboy.data :refer [transform-values]]
             [halboy.json :as haljson]
             [halboy.http.default :as client]
             [halboy.http.protocol :as http]

--- a/src/halboy/params.clj
+++ b/src/halboy/params.clj
@@ -2,11 +2,8 @@
   (:require
     [clojure.walk :refer [postwalk]]
     [clojure.set :refer [difference]]
-
     [medley.core :refer [map-vals]]
-
     [uritemplate-clj.core :refer [uritemplate tokenize parse-token]]
-
     [org.bovinegenius.exploding-fish :as uri]))
 
 (defn- stringify-params [params]

--- a/src/halboy/types.clj
+++ b/src/halboy/types.clj
@@ -1,0 +1,77 @@
+(ns halboy.types
+  (:require [clojure.string :as str]
+            [clojure.walk :refer [keywordize-keys]]
+            [halboy.data :refer [update-if-present]]
+            [cheshire.core :as json])
+  (:import [java.io InputStream]
+           [org.httpkit BytesInputStream]
+           [com.fasterxml.jackson.core JsonParseException]))
+
+(defn- parse-json-response [response]
+  (try
+    (update-if-present response [:body]
+      #(keywordize-keys (json/parse-string %)))
+    (catch JsonParseException ex
+      (assoc response
+        :error {:code :not-valid-json
+                :cause ex}))))
+
+(defn extract-content-type [response]
+  (let [content-type (get-in response [:headers :content-type] "application/json")
+        [media-type properties] (str/split content-type #";" 2)]
+    {:media-type   (str/trim media-type)
+     :charset      (as-> (or properties "") %
+                     (re-find #"charset=([A-Za-z0-9-]+)" %)
+                     (nth % 2 "UTF-8")
+                     (str/upper-case %))
+     :content-type content-type}))
+
+(def ^:private json-media-type?
+  #{"application/json"
+    "application/hal+json"})
+
+(defn- json-content-type? [response]
+  (let [content-type (extract-content-type response)]
+    (json-media-type? (:media-type content-type))))
+
+(defn- with-json-body [m]
+  (update-if-present m [:body] json/generate-string))
+
+(defn if-json-encode-body [request]
+  (if (json-content-type? request)
+    (with-json-body request)
+    request))
+
+(defprotocol Stringify
+  (stringify [this charset] "Convert \"this\" to a string with \"charset\"."))
+
+(extend-protocol Stringify
+  (class (byte-array 0))
+  (stringify [this charset]
+    (String. ^bytes this ^String charset))
+  nil
+  (stringify [_ _] nil)
+  String
+  (stringify [this _] this)
+  BytesInputStream
+  (stringify [this charset]
+    (stringify (.bytes this) ^String charset))
+  InputStream
+  (stringify [this charset]
+    (stringify (.readAllBytes this) ^String charset)))
+
+(defn- stream-body->string-body [response ^String charset]
+  (if (:body response)
+    (update response :body stringify charset)
+    response))
+
+(defn coerce-response-type [response]
+  (let [{:keys [media-type charset]} (extract-content-type response)]
+    (cond
+      (str/includes? media-type "json")
+      (parse-json-response (stream-body->string-body response charset))
+      (or (str/starts-with? media-type "text/")
+          (str/includes? media-type "xml"))
+      (stream-body->string-body response charset)
+      :else
+      response)))

--- a/src/halboy/types.clj
+++ b/src/halboy/types.clj
@@ -46,9 +46,6 @@
   (stringify [this charset] "Convert \"this\" to a string with \"charset\"."))
 
 (extend-protocol Stringify
-  (class (byte-array 0))
-  (stringify [this charset]
-    (String. ^bytes this ^String charset))
   nil
   (stringify [_ _] nil)
   String
@@ -59,6 +56,11 @@
   InputStream
   (stringify [this charset]
     (stringify (.readAllBytes this) ^String charset)))
+
+(extend (class (byte-array 0))
+  Stringify
+  {:stringify (fn [this charset]
+                (String. ^bytes this ^String charset))})
 
 (defn- stream-body->string-body [response ^String charset]
   (if (:body response)

--- a/test/halboy/http/cachable_test.clj
+++ b/test/halboy/http/cachable_test.clj
@@ -4,11 +4,16 @@
             [halboy.http.cachable :as cachable-http-client]
             [clojure.core.cache :as cache]
             [halboy.http.protocol :as http]))
+
 (def base-url "https://service.example.com")
+
 (deftest halboy-http
   (testing "cachableHttpClient without cached data"
     (with-fake-http
-      [{:url base-url :method :get} {:status 201 :body "{}"}]
+      [{:url base-url :method :get} {:status 201
+                                     :headers {:content-type "application/json"
+                                               :server       "org.httpkit.fake"}
+                                     :body "{}"}]
       (let [cache-store (cachable-http-client/new-http-client
                           (atom (cache/ttl-cache-factory {} :ttl 2000)))
             client cache-store
@@ -17,10 +22,10 @@
         (is (=
               (http/exchange client request)
               {:body    {}
-               :headers {:content-type "text/html"
+               :headers {:content-type "application/json"
                          :server       "org.httpkit.fake"}
                :raw     {:body    {}
-                         :headers {:content-type "text/html"
+                         :headers {:content-type "application/json"
                                    :server       "org.httpkit.fake"}
                          :opts    {:as      :text
                                    :headers {"Accept"       "application/hal+json"
@@ -29,8 +34,8 @@
                                    :url     "https://service.example.com"}
                          :status  201}
                :status  201
-               :url     "https://service.example.com"}
-              )))))
+               :url     "https://service.example.com"})))))
+
   (testing "cachableHttpClient with cached data"
     (let [request {:url    base-url
                    :method :get}
@@ -40,13 +45,10 @@
                                     "Accept"       "application/hal+json"},
                           :url     base-url,
                           :method  :get}
-                         {:cached true}
-                         }
+                         {:cached true}}
                         :ttl 2000))
-          cached-client (cachable-http-client/new-http-client cache)
-          ]
+          cached-client (cachable-http-client/new-http-client cache)]
       (is (=
             (http/exchange cached-client request)
             {:raw {:cached true}
-             :url nil}
-            )))))
+             :url nil})))))

--- a/test/halboy/http/cachable_test.clj
+++ b/test/halboy/http/cachable_test.clj
@@ -7,7 +7,7 @@
 
 (def base-url "https://service.example.com")
 
-(deftest halboy-http
+(deftest halboy-http-cache
   (testing "cachableHttpClient without cached data"
     (with-fake-http
       [{:url base-url :method :get} {:status 201
@@ -27,7 +27,7 @@
                :raw     {:body    {}
                          :headers {:content-type "application/json"
                                    :server       "org.httpkit.fake"}
-                         :opts    {:as      :text
+                         :opts    {:as      :stream
                                    :headers {"Accept"       "application/hal+json"
                                              "Content-Type" "application/json"}
                                    :method  :get
@@ -40,7 +40,7 @@
     (let [request {:url    base-url
                    :method :get}
           cache (atom (cache/ttl-cache-factory
-                        {{:as      :text,
+                        {{:as      :stream,
                           :headers {"Content-Type" "application/json",
                                     "Accept"       "application/hal+json"},
                           :url     base-url,

--- a/test/halboy/http/default_test.clj
+++ b/test/halboy/http/default_test.clj
@@ -24,7 +24,7 @@
                :raw     {:body    "{}"
                          :headers {:content-type "text/html"
                                    :server       "org.httpkit.fake"}
-                         :opts    {:as      :text
+                         :opts    {:as      :stream
                                    :headers {"Accept"       "application/hal+json"
                                              "Content-Type" "application/json"}
                                    :method  :get
@@ -50,7 +50,7 @@
                :raw     {:body    {}
                          :headers {:content-type "application/json"
                                    :server       "org.httpkit.fake"}
-                         :opts    {:as      :text
+                         :opts    {:as      :stream
                                    :headers {"Accept"       "application/hal+json"
                                              "Content-Type" "application/json"}
                                    :method  :get

--- a/test/halboy/http/default_test.clj
+++ b/test/halboy/http/default_test.clj
@@ -7,19 +7,21 @@
 (def base-url "https://service.example.com")
 
 (deftest halboy-http
-  (testing "defaultHttpClient"
+  (testing "defaultHttpClient HTML Content-Type header"
     (with-fake-http
-      [{:url base-url :method :get} {:status 201 :body "{}"}]
+      [{:url base-url :method :get} {:status 201
+                                     :headers {:content-type "text/html"
+                                               :server       "org.httpkit.fake"}
+                                     :body "{}"}]
       (let [client (http-client/new-http-client)
             request {:url    base-url
                      :method :get}]
         (is (=
               (http/exchange client request)
-              {:body    {}
+              {:body    "{}"
                :headers {:content-type "text/html"
                          :server       "org.httpkit.fake"}
-
-               :raw     {:body    {}
+               :raw     {:body    "{}"
                          :headers {:content-type "text/html"
                                    :server       "org.httpkit.fake"}
                          :opts    {:as      :text
@@ -29,5 +31,30 @@
                                    :url     "https://service.example.com"}
                          :status  201}
                :status  201
-               :url     "https://service.example.com"}
-              ))))))
+               :url     "https://service.example.com"})))))
+
+  (testing "defaultHttpClient JSON Content-Type header"
+    (with-fake-http
+      [{:url base-url :method :get} {:status 201
+                                     :headers {:content-type "application/json"
+                                               :server       "org.httpkit.fake"}
+                                     :body "{}"}]
+      (let [client (http-client/new-http-client)
+            request {:url    base-url
+                     :method :get}]
+        (is (=
+              (http/exchange client request)
+              {:body    {}
+               :headers {:content-type "application/json"
+                         :server       "org.httpkit.fake"}
+               :raw     {:body    {}
+                         :headers {:content-type "application/json"
+                                   :server       "org.httpkit.fake"}
+                         :opts    {:as      :text
+                                   :headers {"Accept"       "application/hal+json"
+                                             "Content-Type" "application/json"}
+                                   :method  :get
+                                   :url     "https://service.example.com"}
+                         :status  201}
+               :status  201
+               :url     "https://service.example.com"}))))))

--- a/test/halboy/support/api.clj
+++ b/test/halboy/support/api.clj
@@ -11,6 +11,7 @@
 (defn on-discover [url & kvs]
   [{:method :get :url url}
    {:status 200
+    :headers {"Content-Type" "application/hal+json"}
     :body   (-> (new-resource)
                 ((partial apply add-links) kvs)
                 resource->json)}])
@@ -107,4 +108,3 @@
     :url     url
     :headers headers}
    response])
-


### PR DESCRIPTION
## Changes

- Check Content-Type header before attempting to parse as JSON.
  - When Halboy receives a non-JSON response it will now return an empty resource, with the real response accessible from `(hal/response resource)`.
  - Previously it assumed that all responses were JSON and if they weren't it would throw an exception.
- Added an extendable, automatic type coercion system (see the `Stringify` protocol in `types.clj`).
- Updated dependencies.
- Code simplification/deduplication.
- Increased version to v6 as this is a fairly large set of changes (if you disagree, please change this to whatever you'd like).

## Breakage

The only (known) breakage is for tests that use Http-Kit-Fake.  When you mock an HTTP response with Http-Kit-Fake, if no Content-Type header is given, it will add `text/html`, which means that Halboy won't know that it is a HAL+JSON response.  To fix this you just need to add this line

```clojure
:headers {:content-type "application/hal+json"}
```
to each mocked response.  (As seen in the changes to `test/halboy/navigator_test.clj`).

(This is just an issue in the tests, no breakage will occur in actual programs.)