### PR TITLE
Fix a bug in deep-merge that turns false into nil

### DIFF
--- a/src/halboy/argutils.clj
+++ b/src/halboy/argutils.clj
@@ -34,5 +34,5 @@
             (if (and (map? v1) (map? v2))
               (merge-with deep-merge v1 v2)
               v2))]
-    (when (some identity vs)
+    (when (seq vs)
       (reduce #(rec-merge %1 %2) v vs))))


### PR DESCRIPTION
Current implementation behaviour:
```
(deep-merge {:x true} {:x false})
;; => {:x nil}
```

After the fix:
```
(deep-merge {:x true} {:x false})
;; => {:x false}
```

This is currently a problem when using clj-http and setting `{:http {:throw-exceptions false}}` because internally it specifically uses the `false?` predicate, which behaves differently for `false` and `nil`.